### PR TITLE
Add Client Token Auth URL to Whitelist

### DIFF
--- a/whitelist.js
+++ b/whitelist.js
@@ -44,4 +44,7 @@ module.exports = [
     "audio4-ak.spotify.com.edgesuite.net", // audio
     "scontent*.fbcdn.net", // Facebook profile images
     "audio-sp-*.spotifycdn.net", // audio
+    "clienttoken.spotify.com", // Client tokens and auth
+    "104.154.126.102", // Google Cloud Provider (might be tracking idk)
+    "35.190.245.221", // Google Cloud Provider (might be tracking idk)
 ];

--- a/whitelist.js
+++ b/whitelist.js
@@ -45,6 +45,4 @@ module.exports = [
     "scontent*.fbcdn.net", // Facebook profile images
     "audio-sp-*.spotifycdn.net", // audio
     "clienttoken.spotify.com", // Client tokens and auth
-    "104.154.126.102", // Google Cloud Provider (might be tracking idk)
-    "35.190.245.221", // Google Cloud Provider (might be tracking idk)
 ];


### PR DESCRIPTION
In these commits, I added `clienttoken.spotify.com` to the whitelist. This was being blocked before because it was neither on the whitelist nor blacklist. It has now been added. From what I can see, this URL is used by Spotify to grab a new token from the authentication server. Since it was being blocked, the application would fail to start and load user data.

I tested this locally on a Windows 10 machine with the latest version of Spotify installed. After about an hour, I can say with confidence that ads are not loaded from this URL.